### PR TITLE
add 'onActivated`

### DIFF
--- a/.flutter-plugins
+++ b/.flutter-plugins
@@ -1,8 +1,0 @@
-# This is a generated file; do not edit or check into version control.
-url_launcher=/home/dave/.pub-cache/hosted/pub.dev/url_launcher-6.1.11/
-url_launcher_android=/home/dave/.pub-cache/hosted/pub.dev/url_launcher_android-6.0.34/
-url_launcher_ios=/home/dave/.pub-cache/hosted/pub.dev/url_launcher_ios-6.1.4/
-url_launcher_linux=/home/dave/.pub-cache/hosted/pub.dev/url_launcher_linux-3.0.5/
-url_launcher_macos=/home/dave/.pub-cache/hosted/pub.dev/url_launcher_macos-3.0.5/
-url_launcher_web=/home/dave/.pub-cache/hosted/pub.dev/url_launcher_web-2.0.16/
-url_launcher_windows=/home/dave/.pub-cache/hosted/pub.dev/url_launcher_windows-3.0.6/

--- a/lib/dhali_wallet_widget.dart
+++ b/lib/dhali_wallet_widget.dart
@@ -27,6 +27,7 @@ class WalletHomeScreen extends StatefulWidget {
       this.appBarTextColor,
       this.appBarColor,
       this.buttonsColor,
+      this.onActivation,
       this.isImported = true});
 
   final Color? bodyColor;
@@ -38,6 +39,7 @@ class WalletHomeScreen extends StatefulWidget {
   final String title;
   final DhaliWallet? Function() getWallet;
   final Function(DhaliWallet) setWallet;
+  final void Function()? onActivation;
 
   @override
   State<WalletHomeScreen> createState() => _WalletHomeScreenState();
@@ -130,6 +132,9 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
                                         testMode: true);
                                     widget.setWallet(wallet);
                                     _publicKey = wallet.publicKey();
+                                    if (widget.onActivation != null) {
+                                      widget.onActivation!();
+                                    }
                                   });
                                 },
                                 child: const Padding(
@@ -225,6 +230,9 @@ class _WalletHomeScreenState extends State<WalletHomeScreen> {
                                           testMode: true);
                                       widget.setWallet(wallet);
                                       _publicKey = wallet.publicKey();
+                                      if (widget.onActivation != null) {
+                                        widget.onActivation!();
+                                      }
                                     }
                                   });
                                 },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,23 +3,59 @@ import 'package:dhali_wallet/dhali_wallet_widget.dart';
 import 'package:dhali_wallet/xrpl_wallet.dart';
 import 'package:flutter/material.dart';
 
-Future<void> main() async {
+class MainApp extends StatefulWidget {
+  @override
+  _MainAppState createState() => _MainAppState();
+}
+
+class _MainAppState extends State<MainApp> {
   DhaliWallet? _wallet;
-  runApp(
-    MaterialApp(
+  bool _activated = false;
+  Key _key = UniqueKey();
+
+  void _activateWallet() {
+    setState(() {
+      _activated = true;
+    });
+  }
+
+  void _removeFloatingActionButton() {
+    setState(() {
+      _key = UniqueKey();
+      _activated = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
       theme: ThemeData.dark(),
-      home: WalletHomeScreen(
-        isImported: false,
-        bodyTextColor: Color.fromARGB(255, 255, 255, 255),
-        buttonsColor: Color.fromARGB(255, 255, 0, 212),
-        title: "wallet",
-        getWallet: () {
-          return _wallet;
-        },
-        setWallet: (DhaliWallet wallet) {
-          _wallet = wallet;
-        },
+      home: Scaffold(
+        body: WalletHomeScreen(
+          isImported: false,
+          bodyTextColor: Color.fromARGB(255, 255, 255, 255),
+          buttonsColor: Color.fromARGB(255, 255, 0, 212),
+          title: "wallet",
+          getWallet: () {
+            return _wallet;
+          },
+          setWallet: (DhaliWallet wallet) {
+            _wallet = wallet;
+          },
+          onActivation: _activateWallet,
+        ),
+        floatingActionButton: _activated
+            ? FloatingActionButton.extended(
+                label: Text("Press me to make me disappear!"),
+                onPressed: _removeFloatingActionButton,
+              )
+            : null,
+        floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
       ),
-    ),
-  );
+    );
+  }
+}
+
+Future<void> main() async {
+  runApp(MainApp());
 }


### PR DESCRIPTION
## What does this PR do
* Adds an 'onActivated' method to the `DhaliWallet`
* This should enable us to inject e.g. a floating action button to navigate elsewhere in the app, once the wallet has been activated.
* I've removed the `.flutter-plugins` directory, since this contains local paths

## How should this PR be tested?
- [ ]  `flutter run`, activate a wallet.  Confirm that a floating action button appears
- [ ] Click the floating action button.  Confirm that it disappears
- [ ] Confirm that the floating action button appears in other expected scenarios

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
